### PR TITLE
build: Fix compilation with older libstdc++

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4719,7 +4719,7 @@ parseNondetName(const std::string& name) {
           break;
         default:
           klee_warning("Invalid nondet object name: %s", name.c_str());
-          return {fun, line, col};//, seq};
+          return std::make_tuple(fun, line, col);//, seq);
       };
 
       last_semicol = i;
@@ -4731,7 +4731,7 @@ parseNondetName(const std::string& name) {
             // this is probably a nondet global
             fun = name;
         }
-        return {fun, line, col};
+        return std::make_tuple(fun, line, col);
     }
     // parse the column and instance number
     unsigned inst_start = 0, inst_end = 0;
@@ -4749,7 +4749,7 @@ parseNondetName(const std::string& name) {
     } else {
         col = stoi(name.substr(last_semicol + 1));
     }
-    return {fun, line, col};
+    return std::make_tuple(fun, line, col);
 }
 
 static ConcreteValue getConcreteValue(unsigned bytesNum,


### PR DESCRIPTION
The problem is the same as was with `dg`. If you update corresponding git submodules of Symbiotic after merging this, the CI should finally work.

Introduced by: 2cf7391

Fixes:
```
[ 87%] Building CXX object lib/Core/CMakeFiles/kleeCore.dir/Executor.cpp.o
/klee/lib/Core/Executor.cpp: In function ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int> parseNondetName(const string&)’:
/klee/lib/Core/Executor.cpp:4722:33: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int>’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned int&, unsigned int&}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int}]’
           return {fun, line, col};//, seq};
                                 ^
/klee/lib/Core/Executor.cpp:4734:31: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int>’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned int&, unsigned int&}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int}]’
         return {fun, line, col};
                               ^
/klee/lib/Core/Executor.cpp:4752:27: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int>’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, unsigned int&, unsigned int&}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int}]’
     return {fun, line, col};
                           ^
```