### PR TITLE
Fix various compiler warnings

### DIFF
--- a/include/klee/Expr/Assignment.h
+++ b/include/klee/Expr/Assignment.h
@@ -48,6 +48,14 @@ namespace klee {
         content[i] = other[i];
       }
     }
+
+    MapArrayModel& operator=(const MapArrayModel &other) {
+      if (this != &other)
+        content = other.content;
+
+      return *this;
+    }
+
     std::map<uint32_t, uint8_t> asMap() const {
       return content;
     }

--- a/include/klee/Internal/Module/Cell.h
+++ b/include/klee/Internal/Module/Cell.h
@@ -13,8 +13,7 @@
 #include <klee/KValue.h>
 
 namespace klee {
-  class Cell : public KValue {
-  public:
+  struct Cell : public KValue {
     Cell() {}
     Cell(const KValue &other) : KValue(other) {}
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4426,7 +4426,7 @@ bool Executor::getSymbolicSolution(const ExecutionState &state,
     auto value = pair.first;
     tmp.addConstraint(EqExpr::create(it.value.getValue(), value));
 
-    pair = std::move(solver->getRange(tmp, it.value.getSegment()));
+    pair = solver->getRange(tmp, it.value.getSegment());
     auto segment = pair.first;
     tmp.addConstraint(EqExpr::create(it.value.getSegment(), segment));
 

--- a/lib/Expr/Assignment.cpp
+++ b/lib/Expr/Assignment.cpp
@@ -31,7 +31,7 @@ void Assignment::createConstraintsFromAssignment(
        it != ie; ++it) {
     const Array *array = it->first;
     const auto &values = it->second;
-    for (const auto pair : values.asMap()) {
+    for (const auto &pair : values.asMap()) {
       unsigned arrayIndex = pair.first;
       unsigned char value = pair.second;
       out.push_back(EqExpr::create(
@@ -46,7 +46,7 @@ void MapArrayModel::toCompact(CompactArrayModel& model) const {
   model.skipRanges.clear();
   model.values.clear();
   unsigned cursor = 0;
-  for (const auto item : content) {
+  for (const auto &item : content) {
     unsigned difference = item.first - cursor;
     if (shouldSkip(difference)) {
       model.skipRanges.push_back(std::make_pair(cursor, difference));
@@ -60,7 +60,7 @@ void MapArrayModel::toCompact(CompactArrayModel& model) const {
 
 uint8_t CompactArrayModel::get(unsigned index) const {
   unsigned skipTotal = 0;
-  for (const auto item : skipRanges) {
+  for (const auto &item : skipRanges) {
     unsigned skipStart = item.first;
     unsigned skipCount = item.second;
     unsigned skipEnd = skipStart + skipCount;
@@ -83,7 +83,7 @@ std::map<uint32_t, uint8_t> CompactArrayModel::asMap() const {
   std::map<uint32_t, uint8_t> retMap;
   unsigned index = 0;
   unsigned cursor = 0;
-  for (const auto item : skipRanges) {
+  for (const auto &item : skipRanges) {
     for (; index < item.first; index++, cursor++) {
       retMap[index] = values[cursor];
     }
@@ -99,7 +99,7 @@ std::vector<uint8_t> CompactArrayModel::asVector() const {
   std::vector<uint8_t> result;
   unsigned index = 0;
   unsigned cursor = 0;
-  for (const auto item : skipRanges) {
+  for (const auto &item : skipRanges) {
     for (; index < item.first; index++, cursor++) {
       result.push_back(values[cursor]);
     }

--- a/lib/Solver/FastCexSolver.cpp
+++ b/lib/Solver/FastCexSolver.cpp
@@ -1118,7 +1118,7 @@ FastCexSolver::computeInitialValues(const Query& query,
   // Propogation found a satisfying assignment, compute the initial values.
   std::vector<ref<ReadExpr> > reads;
   findReads(query.expr, true, reads);
-  for (const auto constraint : query.constraints)
+  for (const auto &constraint : query.constraints)
     findReads(constraint, true, reads);
 
   for (ref<ReadExpr> read : reads) {

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -343,7 +343,7 @@ SolverImpl::SolverRunStatus Z3SolverImpl::handleSolverResponse(
 
     std::vector<ref<ReadExpr> > reads;
     findReads(query.expr, true, reads);
-    for (const auto constraint: query.constraints)
+    for (const auto &constraint: query.constraints)
       findReads(constraint, true, reads);
 
     Assignment::map_bindings_ty bindings;


### PR DESCRIPTION
This PR fixes some warnings by GCC and Clang that were introduced solely in this fork of KLEE. There are also some remaining compiler warnings, but most of them were already fixed in upstream.