### PR TITLE
Check memcleanup after abort is called

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3398,6 +3398,18 @@ void Executor::terminateStateOnError(ExecutionState &state,
   Instruction * lastInst;
   const InstructionInfo &ii = getLastNonKleeInternalInstruction(state, &lastInst);
 
+  if (termReason == Executor::Abort && CheckMemCleanup) {
+    auto leaks = getMemoryLeaks(state);
+    if (!leaks.empty()) {
+      std::string info = "";
+      for (const auto mo : leaks) {
+        info += getAddressInfo(state, mo->getPointer());
+      }
+      terminateStateOnError(state, "memory error: memory not cleaned up",
+                            Leak, nullptr, info);
+    }
+  }
+
   if (shouldExitOn(termReason))
     haltExecution = true;
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3398,7 +3398,7 @@ void Executor::terminateStateOnError(ExecutionState &state,
   Instruction * lastInst;
   const InstructionInfo &ii = getLastNonKleeInternalInstruction(state, &lastInst);
 
-  if (termReason == Executor::Abort && CheckMemCleanup) {
+  if (CheckMemCleanup) {
     auto leaks = getMemoryLeaks(state);
     if (!leaks.empty()) {
       std::string info = "";


### PR DESCRIPTION
This fixes Symbiotic result on the following benchmark: https://github.com/sosy-lab/sv-benchmarks/blob/master/c/list-properties/list_search-1.c