### PR TITLE
MemoryManager: use multiple allocators for lowmem

### DIFF
--- a/lib/Core/MemoryManager.cpp
+++ b/lib/Core/MemoryManager.cpp
@@ -134,11 +134,29 @@ size_t MmapAllocation::getUsedSize() const {
     return (unsigned char *)nextFreeSlot - (unsigned char *)data;
 }
 
+size_t AllocatorMap::getAppropriateBlockSize(size_t allocationSize) const {
+  return BASE_BLOCK_SIZE * (allocationSize/BASE_BLOCK_SIZE + 1);
+}
+
+MmapAllocator &AllocatorMap::getOrCreateAllocator(size_t blockSize) {
+  auto it = allocators.find(blockSize);
+  if (it == allocators.end()) {
+    it = allocators.emplace_hint(it, blockSize, flags | MAP_32BIT);
+  }
+  return it->second;
+}
+
+void *AllocatorMap::allocate(size_t size, size_t alignment) {
+  size_t blockSize = getAppropriateBlockSize(size);
+  auto &alloc = getOrCreateAllocator(blockSize);
+  return alloc.allocate(size, alignment);
+}
+
 MemoryAllocator::MemoryAllocator(bool determ,
                                  bool lowmem,
                                  size_t determ_size,
                                  void *expectedAddr)
-  : deterministic(determ), lowmemAllocator(4096, MAP_32BIT) {
+  : deterministic(determ) {
   if (deterministic) {
       klee_message("Allocating memory deterministically");
       deterministicMem.initialize(determ_size, expectedAddr);
@@ -159,7 +177,7 @@ void *MemoryAllocator::allocate(size_t size, size_t alignment) {
     }
     return address;
   } else if (lowmem) {
-      return lowmemAllocator.allocate(size, alignment);
+    return lowmemAllocator.allocate(size, alignment);
   } else {
     // Use malloc for the standard case
     if (alignment <= 8)

--- a/lib/Core/MemoryManager.cpp
+++ b/lib/Core/MemoryManager.cpp
@@ -141,7 +141,7 @@ size_t AllocatorMap::getAppropriateBlockSize(size_t allocationSize) const {
 MmapAllocator &AllocatorMap::getOrCreateAllocator(size_t blockSize) {
   auto it = allocators.find(blockSize);
   if (it == allocators.end()) {
-    it = allocators.emplace_hint(it, blockSize, flags | MAP_32BIT);
+    it = allocators.emplace_hint(it, blockSize, flags);
   }
   return it->second;
 }
@@ -156,7 +156,7 @@ MemoryAllocator::MemoryAllocator(bool determ,
                                  bool lowmem,
                                  size_t determ_size,
                                  void *expectedAddr)
-  : deterministic(determ) {
+  : deterministic(determ), lowmemAllocator(MAP_32BIT) {
   if (deterministic) {
       klee_message("Allocating memory deterministically");
       deterministicMem.initialize(determ_size, expectedAddr);

--- a/lib/Core/MemoryManager.h
+++ b/lib/Core/MemoryManager.h
@@ -12,6 +12,7 @@
 
 #include <cstddef>
 #include <set>
+#include <unordered_map>
 #include <vector>
 #include <cstdint>
 
@@ -62,13 +63,29 @@ public:
 };
 
 
+class AllocatorMap {
+  const size_t BASE_BLOCK_SIZE = 4096;
+
+  int flags{0};
+  std::unordered_map<size_t, MmapAllocator> allocators;
+
+  size_t getAppropriateBlockSize(size_t allocationSize) const;
+  MmapAllocator &getOrCreateAllocator(size_t blockSize);
+
+public:
+  AllocatorMap(int flags = 0) : flags(flags) {}
+  void *allocate(size_t size, size_t alignment);
+};
+
 class MemoryAllocator {
     bool deterministic{false};
     // allocate memory on lower 32bit memory space
     bool lowmem{false};
 
+
     MmapAllocation deterministicMem{};
-    MmapAllocator lowmemAllocator{};
+    AllocatorMap lowmemAllocator{};
+
 public:
     MemoryAllocator(bool determ, bool lowmem, size_t determ_size, void *expectedAddr);
 

--- a/lib/Core/MemoryManager.h
+++ b/lib/Core/MemoryManager.h
@@ -84,7 +84,7 @@ class MemoryAllocator {
 
 
     MmapAllocation deterministicMem{};
-    AllocatorMap lowmemAllocator{};
+    AllocatorMap lowmemAllocator;
 
 public:
     MemoryAllocator(bool determ, bool lowmem, size_t determ_size, void *expectedAddr);


### PR DESCRIPTION
This fixes staticafi/klee#9 by always using sufficient block size for given allocation size.
I can confirm klee no longer crashes on big allocations like previously.