### PR TITLE
Fix resource leaks from the POSIX runtime

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -112,6 +112,7 @@ extern "C" {
   void klee_prefer_cex(void *object, uintptr_t condition);
   void klee_posix_prefer_cex(void *object, uintptr_t condition);
   void klee_mark_global(void *object);
+  void klee_unmark_global(void *object);
 
   /* Return a possible constant value for the input expression. This
      allows programs to forcibly concretize values on their own. */

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -106,6 +106,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("klee_is_symbolic", handleIsSymbolic, true),
   add("klee_make_symbolic", handleMakeSymbolic, false),
   add("klee_mark_global", handleMarkGlobal, false),
+  add("klee_unmark_global", handleUnmarkGlobal, false),
   add("klee_open_merge", handleOpenMerge, false),
   add("klee_close_merge", handleCloseMerge, false),
   add("klee_prefer_cex", handlePreferCex, false),
@@ -1269,6 +1270,23 @@ void SpecialFunctionHandler::handleMarkGlobal(ExecutionState &state,
     const MemoryObject *mo = it->first.first;
     assert(!mo->isLocal);
     mo->isGlobal = true;
+  }
+}
+
+void SpecialFunctionHandler::handleUnmarkGlobal(ExecutionState &state,
+                                                KInstruction *target,
+                                                const std::vector<Cell> &arguments) {
+  assert(arguments.size()==1 &&
+         "invalid number of arguments to klee_unmark_global");
+
+  Executor::ExactResolutionList rl;
+  executor.resolveExact(state, arguments[0], rl, "unmark_global");
+
+  for (Executor::ExactResolutionList::iterator it = rl.begin(),
+         ie = rl.end(); it != ie; ++it) {
+    const MemoryObject *mo = it->first.first;
+    assert(!mo->isLocal);
+    mo->isGlobal = false;
   }
 }
 

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -134,6 +134,7 @@ namespace klee {
     HANDLER(handleMalloc);
     HANDLER(handleMemalign);
     HANDLER(handleMarkGlobal);
+    HANDLER(handleUnmarkGlobal);
     HANDLER(handleOpenMerge);
     HANDLER(handleCloseMerge);
     HANDLER(handleNew);

--- a/runtime/Makefile.cmake.bitcode.config.in
+++ b/runtime/Makefile.cmake.bitcode.config.in
@@ -43,6 +43,7 @@ LLVMCC.Flags += $(LLVMCC.ExtraFlags) \
 	-I@CMAKE_BINARY_DIR@/include \
 	-emit-llvm \
 	-std=gnu89 \
+	-g \
 	-D_DEBUG -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
 
 LLVMCC.Warnings += -Wall -Wwrite-strings

--- a/runtime/POSIX/fd.h
+++ b/runtime/POSIX/fd.h
@@ -96,6 +96,9 @@ void klee_init_fds(unsigned n_files, unsigned file_length,
                    int do_all_writes_flag, unsigned max_failures);
 void klee_init_env(int *argcPtr, char ***argvPtr);
 
+void klee_destroy_fds(void);
+void klee_destroy_env(char **argvPtr);
+
 /* *** */
 
 int __fd_open(const char *pathname, int flags, mode_t mode);

--- a/runtime/POSIX/fd_init.c
+++ b/runtime/POSIX/fd_init.c
@@ -159,3 +159,21 @@ void klee_init_fds(unsigned n_files, unsigned file_length,
   __exe_env.version = __sym_uint32("model_version");
   klee_assume(__exe_env.version == 1);
 }
+
+void klee_destroy_fds(void) {
+  unsigned k;
+  for (k = 0; k < __exe_fs.n_sym_files; k++) {
+    free(__exe_fs.sym_files[k].contents);
+    free(__exe_fs.sym_files[k].stat);
+  }
+
+  free(__exe_fs.sym_files);
+  free(__exe_fs.sym_stdin);
+  free(__exe_fs.sym_stdout);
+
+  free(__exe_fs.read_fail);
+  free(__exe_fs.write_fail);
+  free(__exe_fs.close_fail);
+  free(__exe_fs.ftruncate_fail);
+  free(__exe_fs.getcwd_fail);
+}

--- a/runtime/POSIX/klee_init_env.c
+++ b/runtime/POSIX/klee_init_env.c
@@ -60,16 +60,18 @@ static int __streq(const char *a, const char *b) {
   return 0;
 }
 
-static char *__get_sym_str(int numChars, char *name) {
+static char *__get_sym_str(int maxSize, char *name) {
   int i;
-  char *s = malloc(numChars+1);
-  klee_mark_global(s);
-  klee_make_symbolic(s, numChars+1, name);
+  int argSize = klee_range(0, maxSize + 1, "argSize");
 
-  for (i=0; i<numChars; i++)
+  char *s = malloc(argSize + 1);
+  klee_mark_global(s);
+  klee_make_symbolic(s, argSize + 1, name);
+
+  for (i = 0; i < argSize; i++)
     klee_posix_prefer_cex(s, __isprint(s[i]));
-  
-  s[numChars] = '\0';
+
+  s[argSize] = '\0';
   return s;
 }
 

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -511,6 +511,10 @@ void klee_mark_global(void *object) {
   ;
 }
 
+void klee_unmark_global(void *object) {
+  ;
+}
+
 /*** HELPER FUNCTIONS ***/
 
 static void __emit_error(const char *msg) {

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1085,6 +1085,7 @@ static const char *modelledExternals[] = {
   "klee_is_symbolic",
   "klee_make_symbolic",
   "klee_mark_global",
+  "klee_unmark_global",
   "klee_open_merge",
   "klee_close_merge",
   "klee_prefer_cex",


### PR DESCRIPTION
Otherwise, memsafety would always fail due to leaked memory.