### PR TITLE
lazy objects inherit scope of parent

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -5068,8 +5068,9 @@ Executor::handleReadForLazyInit(ExecutionState &state, KInstruction *target,
     }
 
     ref<Expr> size = getPointerSymbolicSizeExpr(state);
-    bool isLocal = false;
+    bool isLocal = mo->isLocal;
     auto *valueMO = executeAlloc(state, size, isLocal, target);
+    valueMO->isGlobal = mo->isGlobal;
     valueMO->isLazyInitialized = true;
     valueMO->pointerDepth = mo->pointerDepth + 1;
 


### PR DESCRIPTION
if parent was local, be local. If it was global, also be global