### PR TITLE
Generating waypoints for YAML witnesses 

### DIFF
--- a/include/klee/Core/Interpreter.h
+++ b/include/klee/Core/Interpreter.h
@@ -174,7 +174,7 @@ public:
   virtual void getCoveredLines(const ExecutionState &state,
                                std::map<const std::string*, std::set<unsigned> > &res) = 0;
 
-  virtual std::pair<unsigned, unsigned> getErrorLocation() = 0;
+  virtual std::tuple<std::string, unsigned, unsigned> getErrorLocation() = 0;
 };
 
 } // End klee namespace

--- a/include/klee/Core/Interpreter.h
+++ b/include/klee/Core/Interpreter.h
@@ -173,6 +173,8 @@ public:
 
   virtual void getCoveredLines(const ExecutionState &state,
                                std::map<const std::string*, std::set<unsigned> > &res) = 0;
+
+  virtual std::pair<unsigned, unsigned> getErrorLocation() = 0;
 };
 
 } // End klee namespace

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -353,6 +353,8 @@ public:
 
   NondetValue& addNondetValue(const KValue &expr, bool isSigned,
                               const std::string& name);
+
+  std::tuple<std::string, unsigned, unsigned> getErrorLocation() const;
 };
 
 struct ExecutionStateIDCompare {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4240,8 +4240,10 @@ void Executor::terminateStateOnError(ExecutionState &state,
     }
   }
 
-  if (shouldExitOn(terminationType))
+  if (shouldExitOn(terminationType)) {
     haltExecution = true;
+    errorLoc = std::make_pair(ii.line, ii.column);
+  }
 
   bool notemitted = emittedErrors.insert(std::make_pair(lastInst, message)).second;
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4242,7 +4242,7 @@ void Executor::terminateStateOnError(ExecutionState &state,
 
   if (shouldExitOn(terminationType)) {
     haltExecution = true;
-    errorLoc = std::make_pair(ii.line, ii.column);
+    errorLoc = state.getErrorLocation();
   }
 
   bool notemitted = emittedErrors.insert(std::make_pair(lastInst, message)).second;

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -118,7 +118,7 @@ private:
   SpecialFunctionHandler *specialFunctionHandler;
   TimerGroup timers;
   std::unique_ptr<PTree> processTree;
-  std::pair<unsigned, unsigned> errorLoc;
+  std::tuple<std::string, unsigned, unsigned> errorLoc;
 
   /// Used to track states that have been added during the current
   /// instructions step. 
@@ -630,7 +630,7 @@ public:
                              KValue &right);
   void checkWidthMatch(KValue &left, KValue &right) const;
   void handleICMPForLazyMO(ExecutionState &state, KValue &value);
-  std::pair<unsigned, unsigned> getErrorLocation() override { return errorLoc; }
+  std::tuple<std::string, unsigned, unsigned> getErrorLocation() override { return errorLoc; }
 
 };
   

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -118,6 +118,7 @@ private:
   SpecialFunctionHandler *specialFunctionHandler;
   TimerGroup timers;
   std::unique_ptr<PTree> processTree;
+  std::pair<unsigned, unsigned> errorLoc;
 
   /// Used to track states that have been added during the current
   /// instructions step. 
@@ -629,6 +630,8 @@ public:
                              KValue &right);
   void checkWidthMatch(KValue &left, KValue &right) const;
   void handleICMPForLazyMO(ExecutionState &state, KValue &value);
+  std::pair<unsigned, unsigned> getErrorLocation() override { return errorLoc; }
+
 };
   
 } // End klee namespace

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -793,12 +793,17 @@ void KleeHandler::processTestCase(const ExecutionState &state,
               continue;
 
           if (input.line > 0 && input.col > 0)
-            *file <<
-            input.getName() << ":" << input.line << ":" << input.col << ":" << input.toString() << "\n";
+            *file << input.getName() << ":"
+                  << input.line << ":"
+                  << input.col << ":"
+                  << input.toString() << "\n";
          }
 
-        std::pair<unsigned, unsigned> errorLoc = m_interpreter->getErrorLocation();
-        *file << "@TARGET:" << errorLoc.first << ":" << errorLoc.second << "\n";
+        auto errorLoc = m_interpreter->getErrorLocation();
+        *file << "@TARGET:"
+              << std::get<0>(errorLoc) << ":"
+              << std::get<1>(errorLoc) << ":"
+              << std::get<2>(errorLoc) << "\n";
 
 
       } else {

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -113,6 +113,11 @@ namespace {
             cl::cat(TestCaseCat));
 
   cl::opt<bool>
+  WriteWaypoints("write-waypoints",
+              cl::desc("Write out witness waypoints to be used in a YML violation witness (default=false)"),
+              cl::cat(TestCaseCat));
+
+  cl::opt<bool>
   WriteHarness("write-harness",
             cl::desc("Write .C file with definitions of nondeterministic functions (default=false)"),
             cl::cat(TestCaseCat));
@@ -774,6 +779,30 @@ void KleeHandler::processTestCase(const ExecutionState &state,
 
       } else {
         klee_warning("unable to write witness file, losing it");
+      }
+    }
+
+    if (WriteWaypoints) {
+      if (auto file = openTestFile("waypoints", id)) {
+
+        auto testvec = m_interpreter->getTestVector(state);
+
+        for (auto& input : testvec) {
+          const auto& name = input.getName();
+          if (name.compare(0, 17 , "__VERIFIER_nondet") != 0)
+              continue;
+
+          if (input.line > 0 && input.col > 0)
+            *file <<
+            input.getName() << ":" << input.line << ":" << input.col << ":" << input.toString() << "\n";
+         }
+
+        std::pair<unsigned, unsigned> errorLoc = m_interpreter->getErrorLocation();
+        *file << "@TARGET:" << errorLoc.first << ":" << errorLoc.second << "\n";
+
+
+      } else {
+        klee_warning("unable to write waypoint file, losing it");
       }
     }
 


### PR DESCRIPTION
With the switch -write-waypoints, JetKlee now outputs a file with information that can be used for generating a (YAML) violation witness. This file contains the return values of the nondet functions and the location of the error instruction.