### PR TITLE
Changes for SV-COMP 2025

### DIFF
--- a/include/klee/Statistics/Statistic.h
+++ b/include/klee/Statistics/Statistic.h
@@ -11,6 +11,7 @@
 #define KLEE_STATISTIC_H
 
 #include <string>
+#include <cstdint>
 
 namespace klee {
   class Statistic;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4404,7 +4404,7 @@ static std::set<std::string> nokExternals({"fesetround", "fesetenv",
                                            "feclearexcept", "feraiseexcept",
                                            "gettext", "dcgettext" , "longjmp", "fgets", "getmntent",
                                            "__freading", "__fwriting", "fread", "fread_unlocked",
-                                           "strspn", "strtod"});
+                                           "strspn", "strtod", "setlocale"});
 
 void Executor::callExternalFunction(ExecutionState &state,
                                     KInstruction *target,

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4282,6 +4282,7 @@ void Executor::terminateStateOnSolverError(ExecutionState &state,
 // XXX shoot me
 static const char *okExternalsList[] = { "printf",
                                          "fprintf",
+					 "vsnprintf",
                                          "sscanf",
                                          "snprintf",
                                          "puts",

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -1106,7 +1106,7 @@ void SpecialFunctionHandler::handleVerifierNondetType(ExecutionState &state,
      //             std::get<0>(nondet).c_str(), std::get<1>(nondet),
      //             std::get<2>(nondet), val.getZExtValue());
 
-      putConcreteValue(state, name, val.isSigned(), target,
+      putConcreteValue(state, name, isSigned, target,
                        ConstantExpr::alloc(val.getZExtValue(), size));
 
     ++position; // matched, move on


### PR DESCRIPTION
This pull requests applies changes that were used for the submission of Symbiotic for SV-COMP 2024.

Compared to SV-COMP 2024, it:
- does not treat `setlocale` as a pure function
- marks `vsnprintf` as an external function
- fixes witness generation with signed values.
