### PR TITLE
Fix issues with expresion width 

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4898,7 +4898,7 @@ void Executor::executeMemoryOperation(ExecutionState &state,
     ref<Expr> offset;
     ref<Expr> segment;
     if (offsetVal) {
-      segment = ConstantExpr::alloc(mo->segment, Expr::Int64);
+      segment = ConstantExpr::alloc(mo->segment, Context::get().getPointerWidth());
       offset = ConstantExpr::alloc(offsetVal.getValue(),
                                    Context::get().getPointerWidth());
     } else {

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -1436,7 +1436,10 @@ void SpecialFunctionHandler::handleScanf(ExecutionState &state,
     }
   }
 
-  auto expr = ConstantExpr::create(realizedArgs, Expr::Int64);
+  if (realizedArgs > INT_MAX)
+    klee_error("scanf: Too many arguments!");
+
+  auto expr = ConstantExpr::create(realizedArgs, Expr::Int32);
   executor.bindLocal(target, state, expr);
 }
 
@@ -1472,6 +1475,9 @@ void SpecialFunctionHandler::handleFscanf(ExecutionState &state,
       ++realizedArgs;
     }
   }
+
+  if (realizedArgs > INT_MAX)
+    klee_error("fcanf: Too many arguments!");
 
   auto expr = ConstantExpr::create(realizedArgs, Expr::Int32);
   executor.bindLocal(target, state, expr);

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -124,6 +124,9 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("malloc", handleMalloc, true),
   add("memalign", handleMemalign, true),
   add("realloc", handleRealloc, true),
+
+  add("__symbiotic_nondet__Bool", handleSymbioticNondet_Bool, true),
+
   add("__VERIFIER_scope_enter", handleScopeEnter, false),
   add("__VERIFIER_scope_leave", handleScopeLeave, false),
   // SV-COMP special functions. We could define them using
@@ -1313,6 +1316,15 @@ void SpecialFunctionHandler::handleVerifierNondetSectorT(ExecutionState &state,
 
   handleVerifierNondetType(state, target, Expr::Int64,
                            /* isSigned = */ false, "__VERIFIER_nondet_sector_t");
+}
+
+void SpecialFunctionHandler::handleSymbioticNondet_Bool(ExecutionState &state,
+                                                       KInstruction *target,
+                                                       const std::vector<Cell> &arguments) {
+  assert(arguments.empty() && "Wrong number of arguments");
+
+  handleVerifierNondetType(state, target, Expr::Bool, // XXX: should we use i1?
+                           /* isSigned = */ false, "__symbiotic_nondet__Bool");
 }
 
 void SpecialFunctionHandler::handleMarkGlobal(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -1473,6 +1473,6 @@ void SpecialFunctionHandler::handleFscanf(ExecutionState &state,
     }
   }
 
-  auto expr = ConstantExpr::create(realizedArgs, Expr::Int64);
+  auto expr = ConstantExpr::create(realizedArgs, Expr::Int32);
   executor.bindLocal(target, state, expr);
 }

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -164,6 +164,7 @@ namespace klee {
     HANDLER(handleDivRemOverflow);
     HANDLER(handleScopeEnter);
     HANDLER(handleScopeLeave);
+    HANDLER(handleSymbioticNondet_Bool);
     HANDLER(handleVerifierNondetInt);
     HANDLER(handleVerifierNondetUInt);
     HANDLER(handleVerifierNondetUInt128);


### PR DESCRIPTION
Fix witdth issues: 
- in fscanf and scanf
- read __symbiotic_nondet__Bool as a boolean expresion
- pointer width in memory operations