### PR TITLE
Allow fgets and fread

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4402,8 +4402,8 @@ static std::set<std::string> nokExternals({"fesetround", "fesetenv",
                                            "feenableexcept", "fedisableexcept",
                                            "feupdateenv", "fesetexceptflag",
                                            "feclearexcept", "feraiseexcept",
-                                           "gettext", "dcgettext" , "longjmp", "fgets", "getmntent",
-                                           "__freading", "__fwriting", "fread", "fread_unlocked",
+                                           "gettext", "dcgettext" , "longjmp", "getmntent",
+                                           "__freading", "__fwriting", "fread_unlocked",
                                            "strspn", "strtod", "setlocale"});
 
 void Executor::callExternalFunction(ExecutionState &state,


### PR DESCRIPTION
Do not forbid `fgets` and `fread`. These are modeled in https://github.com/staticafi/symbiotic/pull/270.