### PR TITLE
Add option for specifying filename for reporting errors

### DIFF
--- a/include/klee/Core/Interpreter.h
+++ b/include/klee/Core/Interpreter.h
@@ -175,6 +175,8 @@ public:
                                std::map<const std::string*, std::set<unsigned> > &res) = 0;
 
   virtual std::tuple<std::string, unsigned, unsigned> getErrorLocation() = 0;
+  virtual void setFileForWitness(const std::string filename) = 0;
+
 };
 
 } // End klee namespace

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -403,7 +403,8 @@ void ExecutionState::addCexPreference(const ref<Expr> &cond) {
 }
 
 // Get the line and column of the errror
-std::tuple<std::string, unsigned, unsigned> ExecutionState::getErrorLocation() const {
+std::tuple<std::string, unsigned, unsigned>
+ExecutionState::getErrorLocation(const std::string& file) const {
   const KInstruction *target = prevPC;
   for (ExecutionState::stack_ty::const_reverse_iterator
          it = stack.rbegin(), ie = stack.rend();
@@ -411,7 +412,9 @@ std::tuple<std::string, unsigned, unsigned> ExecutionState::getErrorLocation() c
     const StackFrame &sf = *it;
     const InstructionInfo &ii = *target->info;
 
-    if (ii.file != "" && ii.line != 0 && ii.column != 0)
+    std::string basename = ii.file.substr(ii.file.find_last_of("/") + 1);
+    if ((file == "" || basename == file)
+        && ii.line != 0 && ii.column != 0)
       return {ii.file, ii.line, ii.column};
     target = sf.caller;
   }

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -354,7 +354,8 @@ public:
   NondetValue& addNondetValue(const KValue &expr, bool isSigned,
                               const std::string& name);
 
-  std::tuple<std::string, unsigned, unsigned> getErrorLocation() const;
+  std::tuple<std::string, unsigned, unsigned>
+    getErrorLocation(const std::string& filename) const;
 };
 
 struct ExecutionStateIDCompare {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4242,7 +4242,7 @@ void Executor::terminateStateOnError(ExecutionState &state,
 
   if (shouldExitOn(terminationType)) {
     haltExecution = true;
-    errorLoc = state.getErrorLocation();
+    errorLoc = state.getErrorLocation(fileForWitness);
   }
 
   bool notemitted = emittedErrors.insert(std::make_pair(lastInst, message)).second;

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -631,9 +631,11 @@ public:
   void checkWidthMatch(KValue &left, KValue &right) const;
   void handleICMPForLazyMO(ExecutionState &state, KValue &value);
   std::tuple<std::string, unsigned, unsigned> getErrorLocation() override { return errorLoc; }
+  std::string fileForWitness = "";
+  void setFileForWitness(const std::string filename) override { fileForWitness = filename; }
 
 };
-  
+
 } // End klee namespace
 
 #endif /* KLEE_EXECUTOR_H */

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -117,6 +117,12 @@ namespace {
               cl::desc("Write out witness waypoints to be used in a YML violation witness (default=false)"),
               cl::cat(TestCaseCat));
 
+  cl::opt<std::string>
+  WaypointsFilename("waypoints-in-file",
+                     cl::init(""),
+                     cl::desc("Write only waypoints from the specified file (default=\"\")"),
+                     cl::cat(TestCaseCat));
+
   cl::opt<bool>
   WriteHarness("write-harness",
             cl::desc("Write .C file with definitions of nondeterministic functions (default=false)"),
@@ -1861,6 +1867,9 @@ int main(int argc, char **argv, char **envp) {
     interpreter->setReplayNondet(ktest);
     kTest_free(ktest);
   }
+
+  if (WriteWaypoints)
+    interpreter->setFileForWitness(WaypointsFilename);
 
   auto startTime = std::time(nullptr);
   { // output clock info and start time


### PR DESCRIPTION
This is a hack to avoid reporting error locations in function models in the SV-COMP setting.

When a property violation happens in a library function that we model, we want to report the place of the function call in the original input program, rather than the location in the function model. This MR adds an option to specify the name of the file that should be considered when reporting property violations. 

In general it would be better to output the whole stack-trace and let Symbiotic decide what to put in the witness (TBD after sv-comp26). 