### PR TITLE
Changes in termination analysis

### DIFF
--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -112,7 +112,8 @@ ExecutionState::ExecutionState(const ExecutionState& state):
                              ? state.unwindingInformation->clone()
                              : nullptr),
     coveredNew(state.coveredNew),
-    forkDisabled(state.forkDisabled) {
+    forkDisabled(state.forkDisabled),
+    storedValues(state.storedValues) {
   for (const auto &cur_mergehandler: openMergeStack)
     cur_mergehandler->addOpenState(this);
 }

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -318,8 +318,9 @@ public:
   /// @brief Disables forking for this state. Set by user code
   bool forkDisabled = false;
 
-  /// @brief Count the number of value stores for termination analysis
-  ssize_t storedValues = 0;
+  /// @brief In termination analysis, track whether the values of loop-modified
+  /// variables were stored
+  bool storedValues = false;
 
 public:
 #ifdef KLEE_UNITTEST

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -318,6 +318,9 @@ public:
   /// @brief Disables forking for this state. Set by user code
   bool forkDisabled = false;
 
+  /// @brief Count the number of value stores for termination analysis
+  ssize_t storedValues = 0;
+
 public:
 #ifdef KLEE_UNITTEST
   // provide this function only in the context of unittests

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1822,6 +1822,8 @@ void Executor::executeCall(ExecutionState &state, KInstruction *ki, Function *f,
 
   // FIXME: hack!
   if (f->getName().equals("__INSTR_check_nontermination")) {
+    if (!state.storedValues)
+        return;
     state.lastLoopCheck = ki->inst;
     // fall-through
   } else if (f->getName().equals("__INSTR_fail")) {

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -1501,10 +1501,10 @@ void SpecialFunctionHandler::handleInstrNondetStore (ExecutionState &state,
                                                      const std::vector<Cell> &arguments) {
   assert(arguments.size() == 0 && "invalid number of arguments");
 
-  if (state.storedValues == 0) {
+  if (!state.storedValues) {
     putConcreteValue(state, "nondet_store", false,
                      target, ConstantExpr::alloc(1, Expr::Bool));
-    state.storedValues++;
+    state.storedValues = true;
     return;
   }
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -155,6 +155,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("__VERIFIER_nondet_ushort", handleVerifierNondetUShort, true),
 
   add("__VERIFIER_assume", handleAssume, false),
+  add("__INSTR_nondet_store", handleInstrNondetStore, true),
 
 #ifdef SUPPORT_KLEE_EH_CXX
   add("_klee_eh_Unwind_RaiseException_impl", handleEhUnwindRaiseExceptionImpl, false),
@@ -1493,4 +1494,23 @@ void SpecialFunctionHandler::handleFscanf(ExecutionState &state,
 
   auto expr = ConstantExpr::create(realizedArgs, Expr::Int32);
   executor.bindLocal(target, state, expr);
+}
+
+void SpecialFunctionHandler::handleInstrNondetStore (ExecutionState &state,
+                                                     KInstruction *target,
+                                                     const std::vector<Cell> &arguments) {
+  assert(arguments.size() == 0 && "invalid number of arguments");
+
+  if (state.storedValues == 0) {
+    putConcreteValue(state, "nondet_store", false,
+                     target, ConstantExpr::alloc(1, Expr::Bool));
+    state.storedValues++;
+    return;
+  }
+
+  executor.bindLocal(target, state,
+                     executor.createNondetValue(state, Expr::Bool,
+                                                false, target,
+                                                "nondet_store", false));
+
 }

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -136,6 +136,7 @@ namespace klee {
     HANDLER(handleGetObjSize);
     HANDLER(handleGetValue);
     HANDLER(handleIsSymbolic);
+    HANDLER(handleInstrNondetStore);
     HANDLER(handleMakeSymbolic);
     HANDLER(handleMalloc);
     HANDLER(handleMemalign);


### PR DESCRIPTION
Reflect changes in termination analysis in Symbiotic. Function `__INSTR_nondet_store` returns a value deciding whether to save the current values of loop-modified variables (previously we did this in every loop-head visit).