### PR TITLE
Add support for __VERIFIER_nondet_ulonglong function

### DIFF
--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -151,6 +151,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("__VERIFIER_nondet_uint", handleVerifierNondetUInt, true),
   add("__VERIFIER_nondet_uint128", handleVerifierNondetUInt128, true),
   add("__VERIFIER_nondet_ulong", handleVerifierNondetULong, true),
+  add("__VERIFIER_nondet_ulonglong", handleVerifierNondetULongLong, true),
   add("__VERIFIER_nondet_unsigned", handleVerifierNondetUnsigned, true),
   add("__VERIFIER_nondet_ushort", handleVerifierNondetUShort, true),
 
@@ -1234,6 +1235,15 @@ void SpecialFunctionHandler::handleVerifierNondetULong(ExecutionState &state,
 
   handleVerifierNondetType(state, target, Expr::Int64,
                            /* isSigned = */ false, "__VERIFIER_nondet_ulong");
+}
+
+void SpecialFunctionHandler::handleVerifierNondetULongLong(ExecutionState &state,
+                                                           KInstruction *target,
+                                                           const std::vector<Cell> &arguments) {
+  assert(arguments.empty() && "Wrong number of arguments");
+
+  handleVerifierNondetType(state, target, Expr::Int64,
+                           /* isSigned = */ false, "__VERIFIER_nondet_ulonglong");
 }
 
 void SpecialFunctionHandler::handleVerifierNondetPointer(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -178,6 +178,7 @@ namespace klee {
     HANDLER(handleVerifierNondetLOffT);
     HANDLER(handleVerifierNondetLong);
     HANDLER(handleVerifierNondetULong);
+    HANDLER(handleVerifierNondetULongLong);
     HANDLER(handleVerifierNondetPointer);
     HANDLER(handleVerifierNondetPChar);
     HANDLER(handleVerifierNondetPthreadT);

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1216,6 +1216,7 @@ static const char *modelledExternals[] = {
   "__VERIFIER_nondet_uchar",
   "__VERIFIER_nondet_uint",
   "__VERIFIER_nondet_ulong",
+  "__VERIFIER_nondet_ulonglong",
   "__VERIFIER_nondet_unsigned",
   "__VERIFIER_nondet_ushort",
   "__VERIFIER_assume",


### PR DESCRIPTION
Fixes: KLEE: WARNING ONCE: Assume that the undefined function __VERIFIER_nondet_ulonglong is pure
in sv-benchmarks/c/intel-tdx-module/** benchmarks.